### PR TITLE
Add FCI implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Then we generate create the molecule (`Molecule` object) and build the integrals
 At any point you can inspect the molecule. For example, you can dump out the (full) integral arrays:
 
 ```
-print mol.S
+print(mol.S)
 ```
 
 which dumps out the overlap matrix:

--- a/mmd/postscf.py
+++ b/mmd/postscf.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import numpy as np
 import sys
 import itertools
+from mmd.slater import *
 
 class PostSCF(object):
     """Class for post-scf routines"""
@@ -23,19 +24,62 @@ class PostSCF(object):
         temp = np.einsum('zs,pqrz->pqrs',
                          self.mol.C,self.mol.single_bar)
         self.mol.single_bar = temp
+
+        # TODO: Make this tx more elegant?
+        # tile spin to make spin orbitals from spatial (twice dimension)
+        self.mol.double_bar = np.zeros([2*idx for idx in self.mol.single_bar.shape])
+        for p in range(self.mol.double_bar.shape[0]):
+            for q in range(self.mol.double_bar.shape[1]):
+                for r in range(self.mol.double_bar.shape[2]):
+                    for s in range(self.mol.double_bar.shape[3]):
+                        value1 = self.mol.single_bar[p//2,r//2,q//2,s//2].real * (p%2==r%2) * (q%2==s%2)
+                        value2 = self.mol.single_bar[p//2,s//2,q//2,r//2].real * (p%2==s%2) * (q%2==r%2)
+                        self.mol.double_bar[p,q,r,s] = value1 - value2
+
+        # create Hp, the spin basis one electron operator 
+        spin = np.eye(2)
+        self.mol.Hp = np.kron(np.einsum('uj,vi,uv', self.mol.C, self.mol.C, self.mol.Core).real,spin)
+
+        # create fs, the spin basis fock matrix eigenvalues 
+        self.mol.fs = np.kron(np.diag(self.mol.MO),spin)
+
+
     
-    def MP2(self):
+    def MP2(self,spin_orbital=False):
         """Routine to compute MP2 energy from RHF reference"""
-        EMP2 = 0.0
-        occupied = range(self.mol.nocc)
-        virtual  = range(self.mol.nocc,self.mol.nbasis)
-        for i,j,a,b in itertools.product(occupied,occupied,virtual,virtual): 
-            denom = self.mol.MO[i] + self.mol.MO[j] \
-                  - self.mol.MO[a] - self.mol.MO[b]
-            numer = self.mol.single_bar[i,a,j,b] \
-                  * (2.0*self.mol.single_bar[i,a,j,b] 
-                    - self.mol.single_bar[i,b,j,a])
-            EMP2 += numer/denom
-        self.mol.emp2 = EMP2 + self.mol.energy   
+        if spin_orbital:
+            # Use spin orbitals from RHF reference
+            EMP2 = 0.0
+            occupied = range(2*self.mol.nocc)
+            virtual  = range(2*self.mol.nocc,2*self.mol.nbasis)
+            for i,j,a,b in itertools.product(occupied,occupied,virtual,virtual): 
+                denom = self.mol.fs[i,i] + self.mol.fs[j,j] \
+                      - self.mol.fs[a,a] - self.mol.fs[b,b]
+                numer = self.mol.double_bar[i,j,a,b]**2 
+                EMP2 += numer/denom
+
+            self.mol.emp2 = 0.25*EMP2 + self.mol.energy   
+        else:
+            # Use spatial orbitals from RHF reference
+            EMP2 = 0.0
+            occupied = range(self.mol.nocc)
+            virtual  = range(self.mol.nocc,self.mol.nbasis)
+            for i,j,a,b in itertools.product(occupied,occupied,virtual,virtual): 
+                denom = self.mol.MO[i] + self.mol.MO[j] \
+                      - self.mol.MO[a] - self.mol.MO[b]
+                numer = self.mol.single_bar[i,a,j,b] \
+                      * (2.0*self.mol.single_bar[i,a,j,b] 
+                        - self.mol.single_bar[i,b,j,a])
+                EMP2 += numer/denom
+            self.mol.emp2 = EMP2 + self.mol.energy   
+
         print('E(MP2) = ', self.mol.emp2.real) 
+
+   
+
+    def FCI(self):
+        """Routine to compute FCI energy from RHF reference"""
+
+
+        print("The End")
 

--- a/mmd/slater.py
+++ b/mmd/slater.py
@@ -1,0 +1,153 @@
+"""
+References: An efficient implementation of Slater-Condon rules
+Anthony Scemama, Emmanuel Giner
+https://arxiv.org/abs/1311.6244
+
+Determinants are represented as (Nint,2) array, where Nint = floor(nMOs/64) + 1 
+"""
+
+import numpy as np
+
+def trailz(i):
+    ''' Returns the number of trailing zero bits for a given integer i '''
+    count = 0
+    while ((i & 1) == 0): # while first bitindex is 0
+        i = i >> 1        # remove trailing bit index
+        count += 1        # increment count and repeat
+    return count
+
+def n_excitations(det1,det2,Nint):
+
+    exc = bin(det1[0,0] ^ det2[0,0]).count('1') +\
+          bin(det1[0,1] ^ det2[0,1]).count('1')
+  
+    for l in range(1,Nint):
+        exc = bin(det1[l,0] ^ det2[l,0]).count('1') +\
+              bin(det1[l,1] ^ det2[l,1]).count('1')
+
+    exc = exc >> 1 # right bitshift by 1 == divide by 2
+
+    return exc
+
+def get_excitation(det1,det2,Nint):
+    exc = np.zeros((3,2,2),dtype=np.int)
+    degree = n_excitations(det1,det2,Nint)
+    if degree > 2:
+        phase = 0
+        degree = -1
+    elif degree == 2:
+        exc, phase = get_double_excitation(det1,det2,Nint)
+    elif degree == 1:
+        exc, phase = get_single_excitation(det1,det2,Nint)
+    elif degree == 0:
+        phase = 1
+        pass 
+
+    return exc, degree, phase
+
+
+def get_single_excitation(det1,det2,Nint):
+    exc = np.zeros((3,2,2),dtype=np.int)
+    phase_dbl = [1,-1]
+
+    for ispin in range(2):
+        ishift = -63
+        for l in range(Nint):
+            ishift += 64
+            if det1[l,ispin] == det2[l,ispin]:
+                continue
+            tmp = det1[l,ispin] ^ det2[l,ispin]
+            particle = tmp & det2[l,ispin]
+            hole = tmp & det1[l,ispin]
+            if particle != 0:
+                tz = trailz(particle) 
+                exc[0,1,ispin] = 1
+                exc[1,1,ispin] = tz + ishift
+            if hole != 0:
+                tz = trailz(hole)
+                exc[0,0,ispin] = 1
+                exc[1,0,ispin] = tz + ishift
+
+            if (exc[0,0,ispin] & exc[0,1,ispin]) == 1:
+                low = min(exc[1,0,ispin],exc[1,1,ispin])
+                high = max(exc[1,0,ispin],exc[1,1,ispin])
+                j = ((low-1) >> 6)
+                n = ((low-1) & 63)
+                k = ((high-1) >> 6) 
+                m = ((high-1) & 63)
+                if j == k:
+                    nperm = bin(det1[j,ispin] & \
+                    (~(1 << n+1)+1 & (1 << m)-1)).count('1')
+                else:
+                    nperm = bin((det1[k,ispin]) & ((1 << m) - 1)).count('1') +\
+                            bin((det1[j,ispin]) & (~(1 << n+1) + 1)).count('1')
+
+                    for i in range(j+1,k):
+                        nperm += bin(det1[i,ispin]).count('1')              
+
+    phase = phase_dbl[nperm & 1]
+    return exc, phase
+
+def get_double_excitation(det1,det2,Nint):
+    exc = np.zeros((3,2,2),dtype=np.int)
+    phase_dbl = [1,-1]
+    nexc = 0
+    nperm = 0
+    for ispin in range(2):
+        idx_particle = 0
+        idx_hole = 0
+        ishift = -63
+        for l in range(Nint):
+            ishift += 64
+            if det1[l,ispin] == det2[l,ispin]:
+                continue
+            tmp = det1[l,ispin] ^ det2[l,ispin]
+            particle = tmp & det2[l,ispin]
+            hole     = tmp & det1[l,ispin]
+            while particle != 0:
+                tz = trailz(particle) 
+                nexc += 1
+                idx_particle += 1
+                exc[0,1,ispin] += 1
+                exc[idx_particle,1,ispin] = tz+ishift
+                particle = particle & (particle - 1)
+            while hole != 0:
+                tz = trailz(hole) 
+                nexc += 1
+                idx_hole += 1
+                exc[0,0,ispin] += 1
+                exc[idx_hole,0,ispin] = tz+ishift
+                hole = hole & (hole - 1)
+            if nexc == 4:
+                break
+
+        for i in range(1,exc[0,0,ispin] + 1): 
+            assert (i == 1) or (i == 2)
+            low = min(exc[i,0,ispin],exc[i,1,ispin])
+            high = max(exc[i,0,ispin],exc[i,1,ispin])
+            j = ((low-1) >> 6)
+            n = ((low-1) & 63)
+            k = ((high-1) >> 6) 
+            m = ((high-1) & 63)
+            if j == k:
+                nperm += bin(det1[j,ispin] & \
+                    (~(1 << n+1)+1 & (1 << m)-1)).count('1')
+            else:
+                nperm += bin((det1[k,ispin]) & ((1 << m) - 1)).count('1') +\
+                        bin((det1[j,ispin]) & (~(1 << n+1) + 1)).count('1')
+ 
+                for l in range(j+1,k):
+                    nperm += bin(det1[l,ispin]).count('1')              
+
+        if exc[0,0,ispin] == 2:
+            a = min(exc[1,0,ispin], exc[1,1,ispin])
+            b = max(exc[1,0,ispin], exc[1,1,ispin])
+            c = min(exc[2,0,ispin], exc[2,1,ispin])
+            d = max(exc[2,0,ispin], exc[2,1,ispin])
+            if ((c > a) and (c < b) and (d > b)):
+                nperm += 1
+            break
+        
+    phase = phase_dbl[nperm & 1]
+    return exc, phase
+

--- a/mmd/slater.py
+++ b/mmd/slater.py
@@ -3,7 +3,8 @@ References: An efficient implementation of Slater-Condon rules
 Anthony Scemama, Emmanuel Giner
 https://arxiv.org/abs/1311.6244
 
-Determinants are represented as (Nint,2) array, where Nint = floor(nMOs/64) + 1 
+Determinants are represented as [Nintp array, where Nint = floor(nMOs/64) + 1 
+Here the determinants are spin-scattered so (alpha, beta) on same string
 """
 
 import numpy as np
@@ -18,19 +19,16 @@ def trailz(i):
 
 def n_excitations(det1,det2,Nint):
 
-    exc = bin(det1[0,0] ^ det2[0,0]).count('1') +\
-          bin(det1[0,1] ^ det2[0,1]).count('1')
-  
+    exc = bin(det1[0] ^ det2[0]).count('1') 
     for l in range(1,Nint):
-        exc += bin(det1[l,0] ^ det2[l,0]).count('1') +\
-               bin(det1[l,1] ^ det2[l,1]).count('1')
+        exc += bin(det1[l] ^ det2[l]).count('1') 
 
     exc = exc >> 1 # right bitshift by 1 == divide by 2
 
     return exc
 
 def get_excitation(det1,det2,Nint):
-    exc = np.zeros((3,2,2),dtype=np.int)
+    exc = np.zeros((3,2),dtype=np.int)
     degree = n_excitations(det1,det2,Nint)
     if degree > 2:
         phase = 0
@@ -47,149 +45,127 @@ def get_excitation(det1,det2,Nint):
 
 
 def get_single_excitation(det1,det2,Nint):
-    exc = np.zeros((3,2,2),dtype=np.int)
+    exc = np.zeros((3,2),dtype=np.int)
     phase_dbl = [1,-1]
 
-    for ispin in range(2):
-        ishift = -63
-        for l in range(Nint):
-            ishift += 64
-            if det1[l,ispin] == det2[l,ispin]:
-                continue
-            tmp = det1[l,ispin] ^ det2[l,ispin]
-            particle = tmp & det2[l,ispin]
-            hole = tmp & det1[l,ispin]
-            if particle != 0:
-                tz = trailz(particle) 
-                exc[0,1,ispin] = 1
-                exc[1,1,ispin] = tz + ishift - 1 # make 0-indexed
-            if hole != 0:
-                tz = trailz(hole)
-                exc[0,0,ispin] = 1
-                exc[1,0,ispin] = tz + ishift - 1 # make 0-indexed
+    ishift = -63
+    for l in range(Nint):
+        ishift += 64
+        if det1[l] == det2[l]:
+            continue
+        tmp = det1[l] ^ det2[l]
+        particle = tmp & det2[l]
+        hole = tmp & det1[l]
+        if particle != 0:
+            tz = trailz(particle) 
+            exc[0,1] = 1
+            exc[1,1] = tz + ishift - 1 # index from 0
+        if hole != 0:
+            tz = trailz(hole)
+            exc[0,0] = 1
+            exc[1,0] = tz + ishift - 1 # index from 0
 
-            if (exc[0,0,ispin] & exc[0,1,ispin]) == 1:
-                low = min(exc[1,0,ispin],exc[1,1,ispin])
-                high = max(exc[1,0,ispin],exc[1,1,ispin])
-                j = ((low) >> 6)
-                n = ((low) & 63)
-                k = ((high) >> 6) 
-                m = ((high) & 63)
-                if j == k:
-                    nperm = bin(det1[j,ispin] & \
-                    (~(1 << n+1)+1 & (1 << m)-1)).count('1')
-                else:
-                    nperm = bin((det1[k,ispin]) & ((1 << m) - 1)).count('1') +\
-                            bin((det1[j,ispin]) & (~(1 << n+1) + 1)).count('1')
-
-                    for i in range(j+1,k):
-                        nperm += bin(det1[i,ispin]).count('1')              
-
-    phase = phase_dbl[nperm & 1]
-    return exc, phase
-
-def get_double_excitation(det1,det2,Nint):
-    exc = np.zeros((3,2,2),dtype=np.int)
-    phase_dbl = [1,-1]
-    nexc = 0
-    nperm = 0
-    for ispin in range(2):
-        idx_particle = 0
-        idx_hole = 0
-        ishift = -63
-        for l in range(Nint):
-            ishift += 64
-            if det1[l,ispin] == det2[l,ispin]:
-                continue
-            tmp = det1[l,ispin] ^ det2[l,ispin]
-            particle = tmp & det2[l,ispin]
-            hole     = tmp & det1[l,ispin]
-            while particle != 0:
-                tz = trailz(particle) 
-                nexc += 1
-                idx_particle += 1
-                exc[0,1,ispin] += 1
-                exc[idx_particle,1,ispin] = tz + ishift - 1 # make 0-indexed
-                particle = particle & (particle - 1)
-            while hole != 0:
-                tz = trailz(hole) 
-                nexc += 1
-                idx_hole += 1
-                exc[0,0,ispin] += 1
-                exc[idx_hole,0,ispin] = tz + ishift - 1 # make 0-indexed
-                hole = hole & (hole - 1)
-            if nexc == 4:
-                break
-
-        for i in range(1,exc[0,0,ispin]+1): 
-            #assert (i == 1) or (i == 2)
-            low = min(exc[i,0,ispin],exc[i,1,ispin])
-            high = max(exc[i,0,ispin],exc[i,1,ispin])
+        if (exc[0,0] & exc[0,1]) == 1:
+            low = min(exc[1,0],exc[1,1])
+            high = max(exc[1,0],exc[1,1])
             j = ((low) >> 6)
             n = ((low) & 63)
             k = ((high) >> 6) 
             m = ((high) & 63)
             if j == k:
-                nperm += bin(det1[j,ispin] & \
-                    (~(1 << n+1)+1 & (1 << m)-1)).count('1')
+                nperm = bin(det1[j] & \
+                (~(1 << n+1)+1 & (1 << m)-1)).count('1')
             else:
-                nperm += bin((det1[k,ispin]) & ((1 << m) - 1)).count('1') +\
-                        bin((det1[j,ispin]) & (~(1 << n+1) + 1)).count('1')
- 
-                for l in range(j+1,k):
-                    nperm += bin(det1[l,ispin]).count('1')              
+                nperm = bin((det1[k]) & ((1 << m) - 1)).count('1') +\
+                        bin((det1[j]) & (~(1 << n+1) + 1)).count('1')
 
-        if exc[0,0,ispin] == 2:
-            a = min(exc[1,0,ispin], exc[1,1,ispin])
-            b = max(exc[1,0,ispin], exc[1,1,ispin])
-            c = min(exc[2,0,ispin], exc[2,1,ispin])
-            d = max(exc[2,0,ispin], exc[2,1,ispin])
-            if ((c > a) and (c < b) and (d > b)):
-                nperm += 1
+                for i in range(j+1,k):
+                    nperm += bin(det1[i]).count('1')              
+
+    phase = phase_dbl[nperm & 1]
+    return exc, phase
+
+def get_double_excitation(det1,det2,Nint):
+    exc = np.zeros((3,2),dtype=np.int)
+    phase_dbl = [1,-1]
+    nexc = 0
+    nperm = 0
+    idx_particle = 0
+    idx_hole = 0
+    ishift = -63
+    for l in range(Nint):
+        ishift += 64
+        if det1[l] == det2[l]:
+            continue
+        tmp = det1[l] ^ det2[l]
+        particle = tmp & det2[l]
+        hole     = tmp & det1[l]
+        while particle != 0:
+            tz = trailz(particle) 
+            nexc += 1
+            idx_particle += 1
+            exc[0,1] += 1
+            exc[idx_particle,1] = tz + ishift - 1 # index from 0
+            particle = particle & (particle - 1)
+        while hole != 0:
+            tz = trailz(hole) 
+            nexc += 1
+            idx_hole += 1
+            exc[0,0] += 1
+            exc[idx_hole,0] = tz + ishift - 1 # index from 0
+            hole = hole & (hole - 1)
+        if nexc == 4:
             break
-        
+
+    for i in range(1,exc[0,0] + 1): 
+        assert (i == 1) or (i == 2)
+        low = min(exc[i,0],exc[i,1])
+        high = max(exc[i,0],exc[i,1])
+        j = ((low) >> 6)
+        n = ((low) & 63)
+        k = ((high) >> 6) 
+        m = ((high) & 63)
+        if j == k:
+            nperm += bin(det1[j] & \
+                (~(1 << n+1)+1 & (1 << m)-1)).count('1')
+        else:
+            nperm += bin((det1[k]) & ((1 << m) - 1)).count('1') +\
+                    bin((det1[j]) & (~(1 << n+1) + 1)).count('1')
+ 
+            for l in range(j+1,k):
+                nperm += bin(det1[l]).count('1')              
+
+    if exc[0,0] == 2:
+        a = min(exc[1,0], exc[1,1])
+        b = max(exc[1,0], exc[1,1])
+        c = min(exc[2,0], exc[2,1])
+        d = max(exc[2,0], exc[2,1])
+        if ((c > a) and (c < b) and (d > b)):
+            nperm += 1
+    
     phase = phase_dbl[nperm & 1]
     return exc, phase
 
 if __name__ == '__main__':
-    det1 = np.array([[0b111,0b111]])
-    det2 = np.array([[0b101010,0b111]])
+    ''' exc index tests '''
+    det1 = np.array([0b111])
+    det2 = np.array([0b101010])
     Nint = 1
     exc, degree, phase = get_excitation(det1,det2,Nint)
-    # first excitationi in double exc is alpha 0->3
-    assert exc[1,0,0] == 0
-    assert exc[1,1,0] == 3
-    # second excitation in double exc is alpha 2->5
-    assert exc[2,0,0] == 2
-    assert exc[2,1,0] == 5
+    # first excitation in double exc is 0->3
+    assert exc[1,0] == 0
+    assert exc[1,1] == 3
+    # second excitation in double exc is 2->5
+    assert exc[2,0] == 2
+    assert exc[2,1] == 5
 
-    det1 = np.array([[0b111,0b111]])
-    det2 = np.array([[0b111,0b1000101]])
+    det1 = np.array([0b111])
+    det2 = np.array([0b1000101])
     Nint = 1
     exc, degree, phase = get_excitation(det1,det2,Nint)
-    # single beta excitation is beta 1->6
-    assert exc[1,0,1] == 1
-    assert exc[1,1,1] == 6
-
-    det1 = np.array([[0b1011,0b111]])
-    det2 = np.array([[0b111,0b10101]])
-    Nint = 1
-    exc, degree, phase = get_excitation(det1,det2,Nint)
-    # alpha single excitation is alpha 3->2
-    assert exc[1,0,0] == 3
-    assert exc[1,1,0] == 2
-    # beta single excitation is beta 1->4
-    assert exc[1,0,1] == 1
-    assert exc[1,1,1] == 4
-
-    det_dict = {0b111: 1, 0b1101: -1, 0b1110: 1, 0b10101: -1, 0b10110: 1, 0b11100: 1, 0b100101: -1, 0b100110: 1, 0b101100: 1, 0b110100: 1, 0b001011: 1, 0b010011: 1, 0b011010: -1, 0b100011: 1, 0b101010: -1, 0b110010: -1, 0b011001: 1, 0b101001: 1, 0b110001: 1}
-    det1 = np.array([[0b111,0b111]])
-    Nint = 1
-    for key in det_dict.keys():
-        det2 = np.array([[key,0b111]])
-        exc, degree, phase = get_excitation(det1,det2,Nint)
-#        print(det1,det2,exc,phase)
-        assert phase == det_dict[key]
+    # single excitation is 1->6
+    assert exc[1,0] == 1
+    assert exc[1,1] == 6
 
 
 

--- a/mmd/slater.py
+++ b/mmd/slater.py
@@ -22,8 +22,8 @@ def n_excitations(det1,det2,Nint):
           bin(det1[0,1] ^ det2[0,1]).count('1')
   
     for l in range(1,Nint):
-        exc = bin(det1[l,0] ^ det2[l,0]).count('1') +\
-              bin(det1[l,1] ^ det2[l,1]).count('1')
+        exc += bin(det1[l,0] ^ det2[l,0]).count('1') +\
+               bin(det1[l,1] ^ det2[l,1]).count('1')
 
     exc = exc >> 1 # right bitshift by 1 == divide by 2
 

--- a/mmd/slater.py
+++ b/mmd/slater.py
@@ -17,6 +17,20 @@ def trailz(i):
         count += 1        # increment count and repeat
     return count
 
+def common_index(det1,det2,Nint):
+    common = []
+    ishift = -64
+    for l in range(Nint):
+        tmp = det1[l] & det2[l]
+        ishift += 64
+        for n in range(63):
+            mask = 1 << n
+            idx_string = tmp & mask
+            if idx_string:
+                common.append(trailz(mask) + ishift)
+
+    return common
+
 def n_excitations(det1,det2,Nint):
 
     exc = bin(det1[0] ^ det2[0]).count('1') 
@@ -32,7 +46,7 @@ def get_excitation(det1,det2,Nint):
     degree = n_excitations(det1,det2,Nint)
     if degree > 2:
         phase = 0
-        degree = -1
+        pass
     elif degree == 2:
         exc, phase = get_double_excitation(det1,det2,Nint)
     elif degree == 1:
@@ -167,5 +181,9 @@ if __name__ == '__main__':
     assert exc[1,0] == 1
     assert exc[1,1] == 6
 
+    det1 = np.array([0b111,0b101,0b11000])
+    det2 = np.array([0b1110,0b1101,0b11000])
+    common = common_index(det1,det2,3)
+    assert set(common) == set([1,2,64,66,131,132])
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy>=1.13.0
 scipy>=0.19.0
 cython>=0.25.0
+bitstring

--- a/sample-input.py
+++ b/sample-input.py
@@ -16,7 +16,3 @@ mol.RHF()
 
 # do MP2
 PostSCF(mol).MP2()
-
-
-
-

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
           'cython',
           'numpy',
           'scipy',
+          'bitstring',
     ],
     long_description=open('README.md').read(),
 #   linetrace directive for cython profiling

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,4 +28,6 @@ test012.py : Boys function test
 test013.py : Test integrals S,T,V and ERI for subcases
 
 test014.py : METHANE 3-21G RMP2
+
+test015.py : Simple tests for Slater-Condon rules
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -32,4 +32,6 @@ test014.py : METHANE 3-21G RMP2
 test015.py : Simple tests for Slater-Condon rules
 
 test016.py : Test MP2 in spatial and spin orbital (checks if integral tx OK)
+
+test017.py : Test FCI for minimal basis water  
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,4 +30,6 @@ test013.py : Test integrals S,T,V and ERI for subcases
 test014.py : METHANE 3-21G RMP2
 
 test015.py : Simple tests for Slater-Condon rules
+
+test016.py : Test MP2 in spatial and spin orbital (checks if integral tx OK)
 ```

--- a/tests/test015.py
+++ b/tests/test015.py
@@ -1,0 +1,12 @@
+import numpy as np
+from mmd.slater import * 
+
+def test_simple_slater_condon():
+    det_dict = {0b111: 1, 0b1101: -1, 0b1110: 1, 0b10101: -1, 0b10110: 1, 0b11100: 1, 0b100101: -1, 0b100110: 1, 0b101100: 1, 0b110100: 1, 0b001011: 1, 0b010011: 1, 0b011010: -1, 0b100011: 1, 0b101010: -1, 0b110010: -1, 0b011001: 1, 0b101001: 1, 0b110001: 1}
+    det1 = np.array([[0b111,0b111]])
+    Nint = 1
+    for key in det_dict.keys():
+        det2 = np.array([[key,0b111]])
+        exc, degree, phase = get_excitation(det1,det2,Nint)
+        assert phase == det_dict[key]
+

--- a/tests/test015.py
+++ b/tests/test015.py
@@ -4,43 +4,34 @@ from mmd.slater import *
 def test_simple_slater_condon():
     ''' phase tests for CISD on (3,6) space'''
     det_dict = {0b111: 1, 0b1101: -1, 0b1110: 1, 0b10101: -1, 0b10110: 1, 0b11100: 1, 0b100101: -1, 0b100110: 1, 0b101100: 1, 0b110100: 1, 0b001011: 1, 0b010011: 1, 0b011010: -1, 0b100011: 1, 0b101010: -1, 0b110010: -1, 0b011001: 1, 0b101001: 1, 0b110001: 1}
-    det1 = np.array([[0b111,0b111]])
+    det1 = np.array([0b111])
     Nint = 1
     for key in det_dict.keys():
-        det2 = np.array([[key,0b111]])
+        det2 = np.array([key])
         exc, degree, phase = get_excitation(det1,det2,Nint)
         assert phase == det_dict[key]
 
 
 def test_exc_index():
     ''' exc index tests '''
-    det1 = np.array([[0b111,0b111]])
-    det2 = np.array([[0b101010,0b111]])
+    det1 = np.array([0b111])
+    det2 = np.array([0b101010])
     Nint = 1
     exc, degree, phase = get_excitation(det1,det2,Nint)
-    # first excitation in double exc is alpha 0->3
-    assert exc[1,0,0] == 0
-    assert exc[1,1,0] == 3
-    # second excitation in double exc is alpha 2->5
-    assert exc[2,0,0] == 2
-    assert exc[2,1,0] == 5
+    print(exc)
+    # first excitation in double exc is 0->3
+    assert exc[1,0] == 0
+    assert exc[1,1] == 3
+    # second excitation in double exc is 2->5
+    assert exc[2,0] == 2
+    assert exc[2,1] == 5
 
-    det1 = np.array([[0b111,0b111]])
-    det2 = np.array([[0b111,0b1000101]])
+    det1 = np.array([0b111])
+    det2 = np.array([0b1000101])
     Nint = 1
     exc, degree, phase = get_excitation(det1,det2,Nint)
-    # single beta excitation is beta 1->6
-    assert exc[1,0,1] == 1
-    assert exc[1,1,1] == 6
-
-    det1 = np.array([[0b1011,0b111]])
-    det2 = np.array([[0b111,0b10101]])
-    Nint = 1
-    exc, degree, phase = get_excitation(det1,det2,Nint)
-    # alpha single excitation is alpha 3->2
-    assert exc[1,0,0] == 3
-    assert exc[1,1,0] == 2
-    # beta single excitation is beta 1->4
-    assert exc[1,0,1] == 1
-    assert exc[1,1,1] == 4
+    # single excitation is 1->6
+    print(exc)
+    assert exc[1,0] == 1
+    assert exc[1,1] == 6
 

--- a/tests/test015.py
+++ b/tests/test015.py
@@ -35,3 +35,8 @@ def test_exc_index():
     assert exc[1,0] == 1
     assert exc[1,1] == 6
 
+def test_common_index():
+    det1 = np.array([0b111,0b101,0b11000])
+    det2 = np.array([0b1110,0b1101,0b11000])
+    common = common_index(det1,det2,3)
+    assert set(common) == set([1,2,64,66,131,132])

--- a/tests/test015.py
+++ b/tests/test015.py
@@ -2,6 +2,7 @@ import numpy as np
 from mmd.slater import * 
 
 def test_simple_slater_condon():
+    ''' phase tests for CISD on (3,6) space'''
     det_dict = {0b111: 1, 0b1101: -1, 0b1110: 1, 0b10101: -1, 0b10110: 1, 0b11100: 1, 0b100101: -1, 0b100110: 1, 0b101100: 1, 0b110100: 1, 0b001011: 1, 0b010011: 1, 0b011010: -1, 0b100011: 1, 0b101010: -1, 0b110010: -1, 0b011001: 1, 0b101001: 1, 0b110001: 1}
     det1 = np.array([[0b111,0b111]])
     Nint = 1
@@ -9,4 +10,37 @@ def test_simple_slater_condon():
         det2 = np.array([[key,0b111]])
         exc, degree, phase = get_excitation(det1,det2,Nint)
         assert phase == det_dict[key]
+
+
+def test_exc_index():
+    ''' exc index tests '''
+    det1 = np.array([[0b111,0b111]])
+    det2 = np.array([[0b101010,0b111]])
+    Nint = 1
+    exc, degree, phase = get_excitation(det1,det2,Nint)
+    # first excitation in double exc is alpha 0->3
+    assert exc[1,0,0] == 0
+    assert exc[1,1,0] == 3
+    # second excitation in double exc is alpha 2->5
+    assert exc[2,0,0] == 2
+    assert exc[2,1,0] == 5
+
+    det1 = np.array([[0b111,0b111]])
+    det2 = np.array([[0b111,0b1000101]])
+    Nint = 1
+    exc, degree, phase = get_excitation(det1,det2,Nint)
+    # single beta excitation is beta 1->6
+    assert exc[1,0,1] == 1
+    assert exc[1,1,1] == 6
+
+    det1 = np.array([[0b1011,0b111]])
+    det2 = np.array([[0b111,0b10101]])
+    Nint = 1
+    exc, degree, phase = get_excitation(det1,det2,Nint)
+    # alpha single excitation is alpha 3->2
+    assert exc[1,0,0] == 3
+    assert exc[1,1,0] == 2
+    # beta single excitation is beta 1->4
+    assert exc[1,0,1] == 1
+    assert exc[1,1,1] == 4
 

--- a/tests/test016.py
+++ b/tests/test016.py
@@ -1,0 +1,31 @@
+import numpy as np
+from mmd.molecule import Molecule
+from mmd.postscf import PostSCF
+
+def test_mp2_spinorbital():
+    helium_dimer = """
+    0 1
+    He   0.0 0.0 0.0
+    He   0.0 0.0 0.75
+    """
+    
+    # init molecule and build integrals
+    mol = Molecule(geometry=helium_dimer,basis='cc-pvDZ')
+    
+    # do the SCF
+    mol.RHF()
+    
+    # do MP2
+    PostSCF(mol).MP2()
+    emp2_spatial = mol.emp2.real
+    PostSCF(mol).MP2(spin_orbital=True)
+    emp2_spin = mol.emp2.real
+   
+    # consistency check 
+    assert emp2_spatial == emp2_spin
+    
+    # G16 reference SCF energy
+    assert np.allclose(-5.29648041091,mol.energy.real)
+    
+    # G16 reference MP2 energy
+    assert np.allclose(-5.3545864180140,emp2_spatial)

--- a/tests/test017.py
+++ b/tests/test017.py
@@ -1,0 +1,27 @@
+import numpy as np
+from mmd.molecule import Molecule
+from mmd.postscf import PostSCF
+
+def test_fci():
+
+    water = """
+    0 1
+    O    0.000000      -0.075791844    0.000000
+    H    0.866811829    0.601435779    0.000000
+    H   -0.866811829    0.601435779    0.000000
+    """
+    
+    # init molecule and build integrals
+    mol = Molecule(geometry=water,basis='sto-3g')
+    
+    # do the SCF
+    mol.RHF()
+
+    # now do FCI
+    PostSCF(mol).FCI() 
+    
+    # Psi4 reference SCF energy
+    assert np.allclose(-74.9420798986,mol.energy.real)
+    
+    # Psi4 reference FCI energy
+    assert np.allclose(-75.0129801827,mol.efci.real)


### PR DESCRIPTION
Implementing naive FCI. Determinant BitStrings are spin-mixed (GHF-style) and the aim is to be easy to modify in the future for selected CI methods, where we lose a lot of the Hamiltonian structure. Therefore, the evaluations are for arbitrary determinant matrix elements.